### PR TITLE
[Feat] 테스트 커버리지 기능 추가

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build:
@@ -56,11 +57,10 @@ jobs:
           docker compose cp server-test:/app/build/reports/jacoco/test/html ./reports/html
 
       - name: Report test Coverage
-        id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
         with:
           title: 📝 Test Coverage Report
-          paths: reports
+          paths: reports/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 95
           min-coverage-changed-files: 95

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -48,3 +48,21 @@ jobs:
         run: |
           docker compose down
           docker compose up --build --exit-code-from server-test
+
+      - name: Copy JaCoCo report to host
+        run: |
+          mkdir -p reports
+          docker compose cp server-test:/app/build/reports/jacoco/test/jacocoTestReport.xml ./reports/
+          docker compose cp server-test:/app/build/reports/jacoco/test/html ./reports/html
+
+      - name: Report test Coverage
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          title: 📝 Test Coverage Report
+          paths: reports
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 95
+          min-coverage-changed-files: 95
+          update-comment: true
+          debug-mode: true

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,4 +2,4 @@
 FROM gradle:8.7-jdk17 AS builder
 WORKDIR /app
 COPY . .
-CMD [ "./gradlew", "clean", "test" ]
+CMD [ "./gradlew", "clean", "test", "jacocoTestReport" ]

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.4'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'ticket'
@@ -16,7 +17,6 @@ java {
 repositories {
 	mavenCentral()
 }
-
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -37,9 +37,16 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
+jacoco {
+	toolVersion = "0.8.12"
+}
+
 test {
 	useJUnitPlatform()
 	jvmArgs "-Xshare:off"
+
+	finalizedBy jacocoTestReport
+	ignoreFailures = true
 
 	testLogging {
 		events "passed", "failed", "skipped"
@@ -66,5 +73,24 @@ test {
 			println "==============================="
 		}
 	}
+}
 
+jacocoTestReport {
+	dependsOn test
+
+	reports {
+		csv.required = true
+		html.required = true
+		xml.required = true
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			limit {
+				minimum = 0.30
+			}
+		}
+	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,4 +70,4 @@ services:
     depends_on:
       server:
         condition: service_healthy
-    command: ["./gradlew", "clean", "test"]
+    command: ["./gradlew", "clean", "test", "jacocoTestReport"]


### PR DESCRIPTION
### 🖥️ issue 번호

#30 

---
### 📄 작업 내용

- 테스트 커버리지 라이브러리 (JaCoCO)를 추가하였습니다. (우선 측정 기준은 95%)
- CI에서 커버리지 결과를 옮긴 후 결과를 업로드 하는 step을 추가하였습니다.

---
### 🎸 PR 기타 사항

- JaCoCO 라이브러리를 사용한 이유는 Java 코드의 커버리지를 체크한 뒤 html이나 xml, csv 같은 다양한 리포트로 생성할 수 있어서 선택하였습니다. 

참조 링크 
- https://techblog.woowahan.com/2661/


